### PR TITLE
Add missing subtypes for the ApolloMessage. Add some more utility factory methods for ApolloMessage

### DIFF
--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/apollo/ApolloMessage.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/apollo/ApolloMessage.java
@@ -24,7 +24,9 @@ import java.util.stream.Collectors;
         @JsonSubTypes.Type(value = InitMessage.class, name = ApolloMessage.GQL_CONNECTION_INIT),
         @JsonSubTypes.Type(value = ApolloMessage.class, name = ApolloMessage.GQL_CONNECTION_TERMINATE),
         @JsonSubTypes.Type(value = ApolloMessage.class, name = ApolloMessage.GQL_STOP),
-        @JsonSubTypes.Type(value = StartMessage.class, name = ApolloMessage.GQL_START)
+        @JsonSubTypes.Type(value = StartMessage.class, name = ApolloMessage.GQL_START),
+        @JsonSubTypes.Type(value = ConnectionErrorMessage.class, name = ApolloMessage.GQL_CONNECTION_ERROR),
+        @JsonSubTypes.Type(value = ErrorMessage.class, name = ApolloMessage.GQL_ERROR),
 })
 @SuppressWarnings("WeakerAccess")
 public class ApolloMessage {
@@ -81,8 +83,12 @@ public class ApolloMessage {
         return jsonMessage(KEEP_ALIVE);
     }
 
+    public static TextMessage connectionError(final String message) throws JsonProcessingException {
+        return jsonMessage(new ConnectionErrorMessage(Collections.singletonMap("message", message)));
+    }
+
     public static TextMessage connectionError() throws JsonProcessingException {
-        return jsonMessage(new ConnectionErrorMessage(Collections.singletonMap("message", "Invalid message")));
+        return connectionError("Invalid message");
     }
 
     public static TextMessage data(String id, ExecutionResult result) throws JsonProcessingException {
@@ -101,7 +107,11 @@ public class ApolloMessage {
     }
 
     public static TextMessage error(String id, Throwable exception) throws JsonProcessingException {
-        return jsonMessage(new ErrorMessage(id, Collections.singletonList(Collections.singletonMap("message", exception.getMessage()))));
+        return error(id, exception.getMessage());
+    }
+
+    public static TextMessage error(String id, String message) throws JsonProcessingException {
+        return jsonMessage(new ErrorMessage(id, Collections.singletonList(Collections.singletonMap("message", message))));
     }
 
     private static TextMessage jsonMessage(ApolloMessage message) throws JsonProcessingException {


### PR DESCRIPTION
@kaqqao I've been using this great project of yours and during some of my integration testing I discovered there were some subtypes missing in the Jackson configuration for the ApolloMessage entity. I also added some factory methods that allow to piggy back off the internal ObjectMapper to create error messages, this is useful to me since I can send custom error messages downstream without having to clone the ObjectMapper configuration in my project.

Let me know if there's any changes you would like to get this PR to be mergeable, thanks for the great work by the way.

