### PR TITLE
Fixing a problem with Websockets and Firefox

### DIFF
--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/GraphQLController.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/GraphQLController.java
@@ -77,7 +77,7 @@ public abstract class GraphQLController<R> {
     @GetMapping(
             value = "${graphql.spqr.http.endpoint:/graphql}",
             produces = MediaType.APPLICATION_JSON_VALUE,
-            headers = "Connection!=Upgrade"
+            headers = { "Connection!=Upgrade", "Connection!=keep-alive, Upgrade" }
     )
     @ResponseBody
     public Object executeGet(GraphQLRequest graphQLRequest, R request) {


### PR DESCRIPTION
If you start the sample project it works with Subscription out-of-the-box but only with Chrome.
As Firefox is sending a different connection header, the subscription request is not properly matched with GraphQLController. Firefox sends: "Connection: keep-alive, Upgrade" header instead of just "Connection: Upgrade"

This fix lets the sample project work out-of-the-box with Firefox.

Steps to reproduce this bug:
1. Clone graphql-spqr-samples
2. Start "spring-boot-starter-sample" on port 8000
3. Start Firefox (my version is 69.0.1)
4. Go to http://localhost:8000/gui and enter a subscription like 
```
subscription follow {
  taskStatusChanged(code: "HELLO-42") {
    code
    status
  }
}
```
GraphiQL response with 

> {
>   "error": "Could not connect to websocket endpoint ws://localhost:8000/graphql. Please check if the endpoint url is correct."
> }

Steps to fix it:
1. Apply this PR.

regards
Janning
