### PR TITLE
Fix travis CI jdk install failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
+dist: trusty


### PR DESCRIPTION
Travis CI reported below error.
```
install-jdk.sh 2019-07-17
Expected feature release number in range of 9 to 14, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```
Looks like this build failed due to the dist: xenial (vs dist: trusty) mentioned here: https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/10