### PR TITLE
fix playground cannot be used offline #82

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,20 @@ To do this SPQR uses `TypeInfoGenerator` on a global level. When using this star
 | graphql.spqr.gui.targetEndpoint | n/a |
 | graphql.spqr.gui.targetWsEndpoint | n/a |
 | graphql.spqr.gui.pageTitle | GraphQL Playground |
+| graphql.spqr.gui.offline | false |
 
+NOTE: If you set `graphic ql.spqr.gui.offline`=`true`, you need to download static files, such as images, CSS files, and JavaScript files, and then put these files in the static directory.
+```bash
+curl -s https://raw.githubusercontent.com/leangen/graphql-spqr-spring-boot-starter/master/graphql-spqr-spring-boot-autoconfigure/src/main/resources/playground.html | \
+ grep -oP "cdn.*?[\"|\']" | \
+ sed "s,['|\"],," | \
+ while read url ; 
+    do 
+      mkdir -p $url ; 
+      rm -rf $url ; 
+      wget -O $url  $url ;
+   done
+```   
 ### Customize mapping of GraphQL values to Java values
 
 Object in charge of doing this in SPQR is `ValueMapperFactory`. Again the simplest way to make use of this when using the starter is to wire a single bean of this type into the application context.

--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/autoconfigure/SpqrProperties.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/autoconfigure/SpqrProperties.java
@@ -228,6 +228,7 @@ public class SpqrProperties {
         private String targetEndpoint;
         private String targetWsEndpoint;
         private String pageTitle = "GraphQL Playground";
+        private boolean offline = false;
 
         public boolean isEnabled() {
             return enabled;
@@ -267,6 +268,14 @@ public class SpqrProperties {
 
         public void setPageTitle(String pageTitle) {
             this.pageTitle = pageTitle;
+        }
+
+        public boolean isOffline() {
+            return offline;
+        }
+
+        public void setOffline(boolean offline) {
+            this.offline = offline;
         }
     }
 }

--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/GuiController.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/GuiController.java
@@ -22,9 +22,13 @@ public class GuiController {
     @ResponseBody
     @RequestMapping(value = "${graphql.spqr.gui.endpoint:/gui}", produces = "text/html; charset=utf-8")
     public String gui() throws IOException {
-        return StreamUtils.copyToString(new ClassPathResource("playground.html").getInputStream(), StandardCharsets.UTF_8)
+        String playgroundHtml = StreamUtils.copyToString(new ClassPathResource("playground.html")
+                .getInputStream(), StandardCharsets.UTF_8)
                 .replace("${pageTitle}", config.getGui().getPageTitle())
                 .replace("${graphQLEndpoint}", config.getGui().getTargetEndpoint())
                 .replace("${webSocketEndpoint}", config.getGui().getTargetWsEndpoint());
+
+        return config.getGui().isOffline() ? playgroundHtml.replace("//", "/")
+                : playgroundHtml;
     }
 }

--- a/graphql-spqr-spring-boot-autoconfigure/src/main/resources/playground.html
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/resources/playground.html
@@ -50,7 +50,7 @@
 </div>
 <script>window.addEventListener('load', function (event) {
     GraphQLPlayground.init(document.getElementById('root'), {
-        // options as 'endpoint' belong here
+        /* options as 'endpoint' belong here */
         endpoint: '${graphQLEndpoint}',
         subscriptionEndpoint: '${webSocketEndpoint}'
     })


### PR DESCRIPTION
Hello !
thanks for this library.

Limited to CDN files cannot be accessed offline.
https://github.com/leangen/graphql-spqr-spring-boot-starter/blob/master/graphql-spqr-spring-boot-autoconfigure/src/main/resources/playground.html

```html
<head>
    <meta charset=utf-8/>
    <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
    <title>${pageTitle}</title>
    <link rel="stylesheet" href="/cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
    <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
    <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
</head>
```
