### PR TITLE
Mono adapter scheduler

### DIFF
--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/modules/reactive/MonoAdapter.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/modules/reactive/MonoAdapter.java
@@ -32,7 +32,6 @@ public class MonoAdapter<T> extends AbstractTypeSubstitutingMapper<T> implements
         this.scheduler = scheduler;
     }
 
-
     @Override
     public GraphQLInputType toGraphQLInputType(AnnotatedType javaType, OperationMapper operationMapper, Set<Class<? extends TypeMapper>> mappersToSkip, BuildContext buildContext) {
         throw new UnsupportedOperationException(ClassUtils.getRawType(javaType.getType()).getSimpleName() + " can not be used as an input type");


### PR DESCRIPTION
MonoAdapter now makes graphql queries work in syncronous manner, because of default Mono behaviour. This PR allows to configure schedulers in MonoAdapter