### PR TITLE
Allow spring data repositories to be exposed through GraphQL.

### DIFF
--- a/graphql-spqr-spring-boot-autoconfigure/pom.xml
+++ b/graphql-spqr-spring-boot-autoconfigure/pom.xml
@@ -75,6 +75,48 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-r2dbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.r2dbc</groupId>
+            <artifactId>r2dbc-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
+
+    <build>
+
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>allow ItemRepository parameter names</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <parameters>true</parameters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+
+    </build>
 
 </project>

--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/modules/data/SpringDataRepositoryResolverBuilder.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/modules/data/SpringDataRepositoryResolverBuilder.java
@@ -1,0 +1,117 @@
+package io.leangen.graphql.spqr.spring.modules.data;
+
+import io.leangen.graphql.metadata.OperationArgument;
+import io.leangen.graphql.metadata.Resolver;
+import io.leangen.graphql.metadata.strategy.query.PropertyOperationInfoGenerator;
+import io.leangen.graphql.metadata.strategy.query.PublicResolverBuilder;
+import io.leangen.graphql.metadata.strategy.query.ResolverBuilderParams;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.reactivestreams.Publisher;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.Repository;
+
+public class SpringDataRepositoryResolverBuilder extends PublicResolverBuilder {
+  public SpringDataRepositoryResolverBuilder(String... basePackages) {
+    super(basePackages);
+    this.operationInfoGenerator = new PropertyOperationInfoGenerator();
+  }
+
+  @Override
+  protected boolean isQuery(Method method, ResolverBuilderParams params) {
+    return super.isQuery(method, params) && inputNotPublisherOrExample(method);
+  }
+
+  private boolean inputNotPublisherOrExample(Method method) {
+    for (Class<?> cls : method.getParameterTypes()) {
+      if (Publisher.class.isAssignableFrom(cls) || Example.class.isAssignableFrom(cls)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  protected boolean isMutation(Method method, ResolverBuilderParams params) {
+    String name = method.getName(); // Spring data repository naming conventions assumed
+    return (name.contains("delete") || name.contains("save") || name.contains("update"))
+      && inputNotPublisherOrExample(method);
+  }
+
+  @Override
+  protected boolean isSubscription(Method method, ResolverBuilderParams params) {
+    return false;
+  }
+
+  @Override
+  protected boolean isPackageAcceptable(Member method, ResolverBuilderParams params) {
+    return true; // This ResolverBuilder is opted into through annotation, wherever it is used, it is valid
+  }
+
+  @Override
+  public Collection<Resolver> buildQueryResolvers(ResolverBuilderParams params) {
+    return renameOperations(super.buildQueryResolvers(params), params);
+  }
+
+  @Override
+  public Collection<Resolver> buildMutationResolvers(ResolverBuilderParams params) {
+    return renameOperations(super.buildMutationResolvers(params), params);
+  }
+
+  @Override
+  public Collection<Resolver> buildSubscriptionResolvers(ResolverBuilderParams params) {
+    return renameOperations(super.buildSubscriptionResolvers(params), params);
+  }
+
+  private Collection<Resolver> renameOperations(Collection<Resolver> resolvers, ResolverBuilderParams params) {
+    Type repositoryResourceType = dataRepositoryType(params);
+    return repositoryResourceType == null ? resolvers
+      : resolvers.stream().map(r -> renameOperation(r, repositoryResourceType)).collect(Collectors.toList());
+  }
+
+  private Type dataRepositoryType(ResolverBuilderParams params) {
+    for (Type t : params.getExposedBeanType().getGenericInterfaces()) {
+      if (ParameterizedType.class.isAssignableFrom(t.getClass())
+        && Repository.class.isAssignableFrom((Class<?>) ((ParameterizedType) t).getRawType())) {
+        return ((ParameterizedType) t).getActualTypeArguments()[0];
+      }
+    }
+    return null;
+  }
+
+  private Resolver renameOperation(Resolver original, Type repositoryResourceType) {
+    String name = original.getOperationName(), typeName = ((Class<?>) repositoryResourceType).getSimpleName();
+    if (name.startsWith("exists")) {
+      name = name.replace("exists", typeName + "Exists");
+    } else if (name.contains("All")) {
+      name = name.replace("All", "All" + typeName + "s");
+    } else if (name.startsWith("find")) {
+      name = name.replace("find", "find" + typeName);
+    } else if (name.startsWith("delete")) {
+      name = name.replace("delete", "delete" + typeName);
+    } else if (name.startsWith("update")) {
+      name = name.replace("update", "update" + typeName);
+    } else if (name.equals("count")) {
+      name = name.replace("count", "count" + typeName + "s");
+    } else {
+      name += typeName;
+    }
+    if (isSorted(original.getArguments())) {
+      name += "Sorted";
+    }
+    return new Resolver(name, original.getOperationDescription(), original.getOperationDeprecationReason(),
+      original.isBatched(), original.getExecutable(), original.getTypedElement(), original.getArguments(),
+      original.getComplexityExpression());
+  }
+
+  private boolean isSorted(List<OperationArgument> arguments) {
+    return arguments.stream().filter(a -> Sort.class.isAssignableFrom(a.getParameter().getType())).count() > 0;
+  }
+
+}

--- a/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/Application.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/Application.java
@@ -1,0 +1,15 @@
+package io.leangen.graphql.spqr.spring.modules.data;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+@SpringBootApplication
+@EnableR2dbcRepositories(basePackageClasses = Application.class)
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+}

--- a/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/Item.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/Item.java
@@ -1,0 +1,39 @@
+package io.leangen.graphql.spqr.spring.modules.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.leangen.graphql.annotations.GraphQLIgnore;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Persistable;
+
+public class Item implements Persistable<Long> {
+  @Id
+  @GraphQLQuery(description = "Item identifier")
+  Long id;
+  @GraphQLQuery(description = "Item name")
+  String name;
+
+  @Override
+  public Long getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  @Override
+  @JsonIgnore
+  @GraphQLIgnore
+  public boolean isNew() {
+    return id == null;
+  }
+}

--- a/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/ItemRepository.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/ItemRepository.java
@@ -1,0 +1,20 @@
+package io.leangen.graphql.spqr.spring.modules.data;
+
+import io.leangen.graphql.spqr.spring.annotations.GraphQLApi;
+import io.leangen.graphql.spqr.spring.annotations.WithResolverBuilder;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@GraphQLApi
+@WithResolverBuilder(SpringDataRepositoryResolverBuilder.class)
+public interface ItemRepository extends R2dbcRepository<Item, Long> {
+  Flux<Item> findAllByName(String name);
+
+  @Modifying
+  @Query("UPDATE item SET name = :name where id = :id")
+  Mono<Integer> updateNameById(String name, Long id);
+
+}

--- a/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/SpringDataRepositoryResolverBuilderTest.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/test/java/io/leangen/graphql/spqr/spring/modules/data/SpringDataRepositoryResolverBuilderTest.java
@@ -1,0 +1,126 @@
+package io.leangen.graphql.spqr.spring.modules.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.BodyInserters;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(locations = "classpath:r2dbc.properties")
+public class SpringDataRepositoryResolverBuilderTest {
+  @LocalServerPort
+  protected int port;
+  @Value("${graphql.spqr.http.endpoint}")
+  private String apiContext;
+  @Autowired
+  private ItemRepository repository;
+
+  private WebTestClient webTestClient;
+
+  private URI uri;
+
+  @Before
+  public void setUp() {
+    webTestClient = WebTestClient.bindToServer().build();
+    uri = URI.create("http://localhost:" + port + "/" + apiContext);
+  }
+
+  @After
+  public void cleanUp() {
+    repository.deleteAll().block(Duration.ofSeconds(1L));
+  }
+
+  @Test
+  public void saveItem() {
+    post("mutation", "saveItem", "entity: {id: null, name: \"saved item name\"}", "name",
+      "{\"data\":{\"saveItem\":[{\"name\":\"saved item name\"}]}}");
+  }
+
+  @Test
+  public void countItems() {
+    post("query", "countItems", null, null, "{\"data\":{\"countItems\":[0]}}");
+    saveNewItem("name");
+    post("query", "countItems", null, null, "{\"data\":{\"countItems\":[1]}}");
+  }
+
+  @Test
+  public void deleteItemById() {
+    Item i = saveNewItem("a name");
+    post("mutation", "deleteItemById", "id: " + i.getId(), null, "{\"data\":{\"deleteItemById\":[]}}");
+    assertFalse(repository.findById(i.getId()).blockOptional(Duration.ofSeconds(1L)).isPresent());
+  }
+
+  @Test
+  public void findItemById() {
+    Item i = saveNewItem("a name");
+    post("query", "findItemById", "id: " + i.getId(), "id name",
+      "{\"data\":{\"findItemById\":[{\"id\":" + i.getId() + ",\"name\":\"a name\"}]}}");
+  }
+
+  @Test
+  public void findAllItemsByName() {
+    saveNewItem("best name");
+    saveNewItem("best name");
+    post("query", "findAllItemsByName", "name: \"best name\"", "name",
+      "{\"data\":{\"findAllItemsByName\":[{\"name\":\"best name\"},{\"name\":\"best name\"}]}}");
+  }
+
+  @Test
+  public void updateItemNameById() {
+    Item i = saveNewItem("old name");
+    post("mutation", "updateItemNameById", "id: " + i.getId() + ", name: \"new name\"", null,
+      "{\"data\":{\"updateItemNameById\":[1]}}");
+  }
+
+  /**
+   * All database to persist new item and update the generated ID.
+   * 
+   * @param name item name
+   * @return item
+   */
+  private Item saveNewItem(String name) {
+    Item i = new Item();
+    i.setName(name);
+    return repository.save(i).block(Duration.ofSeconds(1L));
+  }
+
+  /**
+   * Test helper to send graphQL HTTP Post.
+   * 
+   * @param gqlType query or mutation
+   * @param operation list available in documentation http://localhost:{port}/gui
+   * @param inputData parameters
+   * @param outputFields id and name are options
+   * @param expectedResult response body
+   */
+  private void post(String gqlType, String operation, String inputData, String outputFields, String expectedResult) {
+    webTestClient.post().uri(uri).contentType(MediaType.APPLICATION_JSON)
+      .body(BodyInserters
+        .fromValue(Collections.singletonMap("query", gqlType + " " + gqlSyntax(operation, inputData, outputFields))))
+      .exchange().expectStatus().isOk().expectBody(String.class)
+      .consumeWith(c -> assertThat("", c.getResponseBody(), containsString(expectedResult)));
+  }
+
+  private String gqlSyntax(String operation, String inputData, String outputFields) {
+    return "{" + operation + (inputData == null ? "" : "(" + inputData + ")")
+      + (outputFields == null ? "" : "{" + outputFields + "}") + "}";
+  }
+
+}

--- a/graphql-spqr-spring-boot-autoconfigure/src/test/resources/r2dbc.properties
+++ b/graphql-spqr-spring-boot-autoconfigure/src/test/resources/r2dbc.properties
@@ -1,0 +1,3 @@
+graphql.spqr.http.endpoint=anyendpoint
+graphql.spqr.relay.enabled=false
+graphql.spqr.gui.enabled=true

--- a/graphql-spqr-spring-boot-autoconfigure/src/test/resources/schema.sql
+++ b/graphql-spqr-spring-boot-autoconfigure/src/test/resources/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE ITEM
+(
+    ID             INTEGER IDENTITY PRIMARY KEY,
+    NAME           VARCHAR(255)
+);

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <java.version>1.8</java.version>
 
         <spqr.version>0.11.2</spqr.version>
-        <spring-boot.version>2.4.2</spring-boot.version>
+        <spring-boot.version>2.5.6</spring-boot.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
The Spring Boot version is updated.  See README changes for details about the new features added by this PR.

BaseAutoConfiguration.java defaultPublicResolverBuilder() was unable to determine the correct beanType for autogenerated repositories without this change.