### PR TITLE
Specify correct spring boot starter version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use this starter in a typical Spring Boot project, add the following dependen
   <dependency>
     <groupId>io.leangen.graphql</groupId>
     <artifactId>graphql-spqr-spring-boot-starter</artifactId>
-    <version>0.07</version>
+    <version>0.0.7</version>
   </dependency>
   <dependency>
     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
I think that's a typo, found it while scrolling randomly through the commits yesterday.