### PR TITLE
Fix Websocket handshake when case-insensitive client is used

### DIFF
--- a/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/GraphQLController.java
+++ b/graphql-spqr-spring-boot-autoconfigure/src/main/java/io/leangen/graphql/spqr/spring/web/GraphQLController.java
@@ -96,7 +96,8 @@ public abstract class GraphQLController<R> {
     @GetMapping(
             value = "${graphql.spqr.http.endpoint:/graphql}",
             produces = MediaType.APPLICATION_JSON_VALUE,
-            headers = { "Connection!=Upgrade", "Connection!=keep-alive, Upgrade" }
+            headers = { "Connection!=Upgrade", "Connection!=keep-alive, Upgrade",
+                        "Connection!=upgrade", "Connection!=keep-alive, upgrade"}
     )
     public Object executeGet(GraphQLRequest graphQLRequest, R request) {
         return get(graphQLRequest, request, TransportType.HTTP);
@@ -105,7 +106,8 @@ public abstract class GraphQLController<R> {
     @GetMapping(
             value = "${graphql.spqr.http.endpoint:/graphql}",
             produces = MediaType.TEXT_EVENT_STREAM_VALUE,
-            headers = { "Connection!=Upgrade", "Connection!=keep-alive, Upgrade" }
+            headers = { "Connection!=Upgrade", "Connection!=keep-alive, Upgrade",
+                        "Connection!=upgrade", "Connection!=keep-alive, upgrade"}
     )
     public Object executeGetEventStream(GraphQLRequest graphQLRequest, R request) {
         return get(graphQLRequest, request, TransportType.HTTP_EVENT_STREAM);


### PR DESCRIPTION
Http controller will intercept Websocket handshake when Websocket client will send the "upgrade" value in the Connection header. When headers are processed,  keys are case insensitive (connection = Connection), but its a different story for the values...

Some clients like in the Spring Gateway (for example the io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker13) will just dont care about the case sensitivity and will send everything in the lower case manner...

Fix is not the prettiest but it works, best way to handle this would be to treat  both the keys and the values for the headers without respecting case of the letters...