### PR TITLE
chore: upgrade graphql-java to resolve CVE-2024-40094

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2024-xx-xx
+### Changed
+- Upgrade to graphql-java v21.5 to resolve CVE-2024-40094
+
 ## [1.0.1] - 2024-01-07
 ### Changed
 - [Breaking] Upgrade to Spring Boot v3.2.1 and SPQR v0.12.4 (graphql-java v21.3) [#140](https://github.com/leangen/graphql-spqr-spring-boot-starter/issues/140)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use this starter in a typical Spring Boot project, add the following dependen
   <dependency>
     <groupId>io.leangen.graphql</groupId>
     <artifactId>graphql-spqr-spring-boot-starter</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.2</version>
   </dependency>
   <dependency>
     <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>com.graphql-java</groupId>
                 <artifactId>graphql-java</artifactId>
-                <version>21.3</version>
+                <version>21.5</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR fixes [CVE-2024-40094](https://nvd.nist.gov/vuln/detail/CVE-2024-40094) (severity 7.5) by upgrading graphql-java from 21.3 to the nearest compatible version, 21.5.